### PR TITLE
Fail when embedded labels are wrong

### DIFF
--- a/init.go
+++ b/init.go
@@ -221,7 +221,9 @@ func findLabelIndexes(typ reflect.Type, indexes map[label][]int, current ...int)
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 		if f.Type.Kind() == reflect.Struct {
-			findLabelIndexes(f.Type, indexes, append(current, i)...)
+			if err := findLabelIndexes(f.Type, indexes, append(current, i)...); err != nil {
+				return err
+			}
 		} else {
 
 			labelTag, ok := f.Tag.Lookup("label")


### PR DESCRIPTION
We were not checking the error when recursively checking embedded label
structs.

Additionally some code coverage is improved.