### PR TITLE
Improve test coverage

### DIFF
--- a/default_test.go
+++ b/default_test.go
@@ -1,0 +1,121 @@
+package gotoprom
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/cabify/gotoprom/prometheusvanilla"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestMustAddBuilder(t *testing.T) {
+	initializerMock, tearDown := mockDefaultInitializer()
+	defer tearDown()
+	defer initializerMock.AssertExpectations(t)
+
+	expectedErr := errors.New("my err")
+
+	typ := prometheusvanilla.ObserverType
+	builder := func(
+		name, help, namespace string,
+		labelNames []string,
+		tag reflect.StructTag,
+	) (func(prometheus.Labels) interface{}, prometheus.Collector, error) {
+		return nil, nil, expectedErr
+	}
+
+	initializerMock.On("MustAddBuilder", typ, mock.Anything).Run(func(args mock.Arguments) {
+		// we can't assert that two functions are the same, so we invoke it and see if it's ours
+		_, _, err := args[1].(Builder)("", "", "", nil, reflect.StructTag(""))
+		assert.Equal(t, expectedErr, err)
+	}).Once()
+
+	MustAddBuilder(typ, builder)
+}
+
+func TestAddBuilder(t *testing.T) {
+	initializerMock, tearDown := mockDefaultInitializer()
+	defer tearDown()
+	defer initializerMock.AssertExpectations(t)
+
+	expectedErr := errors.New("my err")
+
+	typ := prometheusvanilla.ObserverType
+	builder := func(
+		name, help, namespace string,
+		labelNames []string,
+		tag reflect.StructTag,
+	) (func(prometheus.Labels) interface{}, prometheus.Collector, error) {
+		return nil, nil, expectedErr
+	}
+
+	initializerMock.On("AddBuilder", typ, mock.Anything).Run(func(args mock.Arguments) {
+		// we can't assert that two functions are the same, so we invoke it and see if it's ours
+		_, _, err := args[1].(Builder)("", "", "", nil, reflect.StructTag(""))
+		assert.Equal(t, expectedErr, err)
+	}).Return(expectedErr).Once()
+
+	err := AddBuilder(typ, builder)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestInit(t *testing.T) {
+	initializerMock, tearDown := mockDefaultInitializer()
+	defer tearDown()
+	defer initializerMock.AssertExpectations(t)
+
+	expectedErr := errors.New("my err")
+
+	metrics := struct{ whatever int }{}
+	namespace := "some namespace"
+
+	initializerMock.On("Init", metrics, namespace).Return(expectedErr).Once()
+
+	err := Init(metrics, namespace)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestMustInit(t *testing.T) {
+	initializerMock, tearDown := mockDefaultInitializer()
+	defer tearDown()
+	defer initializerMock.AssertExpectations(t)
+
+	metrics := struct{ whatever int }{}
+	namespace := "some namespace"
+
+	initializerMock.On("MustInit", metrics, namespace).Once()
+
+	MustInit(metrics, namespace)
+}
+
+func mockDefaultInitializer() (mock *InitializerMock, tearDown func()) {
+	original := DefaultInitializer
+	mock = &InitializerMock{}
+	DefaultInitializer = mock
+	return mock, func() { DefaultInitializer = original }
+}
+
+type InitializerMock struct {
+	mock.Mock
+}
+
+func (m *InitializerMock) MustAddBuilder(typ reflect.Type, registerer Builder) {
+	m.Called(typ, registerer)
+}
+
+func (m *InitializerMock) AddBuilder(typ reflect.Type, registerer Builder) error {
+	ret := m.Called(typ, registerer)
+	return ret[0].(error)
+}
+
+func (m *InitializerMock) MustInit(metrics interface{}, namespace string) {
+	m.Called(metrics, namespace)
+}
+
+func (m *InitializerMock) Init(metrics interface{}, namespace string) error {
+	ret := m.Called(metrics, namespace)
+	return ret[0].(error)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,14 @@ go 1.12
 
 require (
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/protobuf v1.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.1
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
 	github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39 // indirect
 	github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
@@ -20,8 +21,11 @@ github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39 h1:Cto4X6SVMWRPB
 github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d h1:GoAlyOgbOEIFdaDqxJVlbOQ1DtGmZWs/Qau0hIlk+WQ=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/init.go
+++ b/init.go
@@ -192,7 +192,7 @@ func (in initializer) initMetricFunc(field reflect.Value, structField reflect.St
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 				labels[label.name] = strconv.FormatInt(value.Int(), 10)
 			default:
-				// Should not happen
+				// Should not happen since we've already checked this in the findLabelIndexes function
 				panic(fmt.Errorf("field %s has unsupported kind %v", label.name, label.kind))
 			}
 		}

--- a/init.go
+++ b/init.go
@@ -35,6 +35,8 @@ type Initializer interface {
 	Init(metrics interface{}, namespace string) error
 }
 
+//go:generate mockery -testonly -inpkg -case underscore -name Notifier
+
 // NewInitializer creates a new Initializer for the prometheus.Registerer provided
 func NewInitializer(registerer prometheus.Registerer) Initializer {
 	return initializer{

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,175 @@
+package gotoprom
+
+import (
+	"testing"
+
+	"github.com/cabify/gotoprom/prometheusvanilla"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializer_MustAddBuilder(t *testing.T) {
+	t.Run("adds builder", func(t *testing.T) {
+		initializer := NewInitializer(prometheus.NewRegistry())
+		initializer.MustAddBuilder(prometheusvanilla.GaugeType, prometheusvanilla.BuildGauge)
+
+		err := initializer.Init(&struct {
+			Metric func() prometheus.Gauge `name:"gauge" help:"help"`
+		}{}, "namespace")
+		assert.NoError(t, err)
+	})
+	t.Run("same builder twice panics", func(t *testing.T) {
+		initializer := NewInitializer(prometheus.NewRegistry())
+		initializer.MustAddBuilder(prometheusvanilla.GaugeType, prometheusvanilla.BuildGauge)
+
+		assert.Panics(t, func() {
+			initializer.MustAddBuilder(prometheusvanilla.GaugeType, prometheusvanilla.BuildGauge)
+		})
+	})
+}
+
+func TestInitializer_AddBuilder(t *testing.T) {
+	t.Run("same builder twice fails", func(t *testing.T) {
+		initializer := NewInitializer(prometheus.NewRegistry())
+		err := initializer.AddBuilder(prometheusvanilla.GaugeType, prometheusvanilla.BuildGauge)
+		assert.NoError(t, err)
+
+		err = initializer.AddBuilder(prometheusvanilla.GaugeType, prometheusvanilla.BuildGauge)
+		assert.Error(t, err)
+	})
+}
+
+func TestInitializer_MustInit(t *testing.T) {
+	t.Run("happy case", func(t *testing.T) {
+		initializer := NewInitializer(prometheus.NewRegistry())
+
+		structPtr := &struct{}{}
+		assert.NotPanics(t, func() {
+			initializer.MustInit(structPtr, "namespace")
+		})
+	})
+
+	t.Run("panics when can't init", func(t *testing.T) {
+		initializer := NewInitializer(prometheus.NewRegistry())
+
+		notAPointer := struct{}{}
+		assert.Panics(t, func() {
+			initializer.MustInit(notAPointer, "namespace")
+		})
+	})
+}
+
+func TestInitializer_Init(t *testing.T) {
+	someInt := 3
+	type someLabels struct {
+		Label string `label:"label"`
+	}
+	type someLabelsWithoutLabelTag struct {
+		LabelWithoutLabelTag string
+	}
+	t.Run("fails", func(t *testing.T) {
+		for _, tc := range []struct {
+			desc    string
+			metrics interface{}
+		}{
+			{
+				desc:    "not a pointer to struct",
+				metrics: struct{}{},
+			},
+			{
+				desc:    "pointer to a non struct",
+				metrics: &someInt,
+			},
+			{
+				desc: "contains a non-supported field, like a string",
+				metrics: &struct {
+					Something string
+				}{},
+			},
+			{
+				desc: "sub-struct doesn't define its namespace",
+				metrics: &struct {
+					Inner struct{}
+				}{},
+			},
+			{
+				desc: "sub-struct can't be initialized",
+				metrics: &struct {
+					Inner struct {
+						Deeper struct{} `thisdoesnothaveanamespace:"nothing"`
+					} `namespace:"thishasanamespace"`
+				}{},
+			},
+			{
+				desc: "non-exported field",
+				metrics: &struct {
+					foo func() prometheus.Gauge `name:"unexported" help:"this can't be set"`
+				}{},
+			},
+			{
+				desc: "missing name",
+				metrics: &struct {
+					Foo func() prometheus.Gauge `help:"missing name tag"`
+				}{},
+			},
+			{
+				desc: "missing help",
+				metrics: &struct {
+					Foo func() prometheus.Gauge `name:"nohelp"`
+				}{},
+			},
+			{
+				desc: "more than one return argument",
+				metrics: &struct {
+					Foo func() (prometheus.Gauge, error) `name:"toomanyreturnargs" help:"what is this?"`
+				}{},
+			},
+			{
+				desc: "no builders defined",
+				metrics: &struct {
+					Foo func() prometheus.Counter `name:"unknowntype" help:"Counter is not registered"`
+				}{},
+			},
+			{
+				desc: "builder fails",
+				metrics: &struct {
+					Foo func() prometheus.Summary `name:"unknowntype" help:"max_age is malformed" max_age:"bar"`
+				}{},
+			},
+			{
+				desc: "builder fails",
+				metrics: &struct {
+					Foo func() prometheus.Summary `name:"unknowntype" help:"max_age is malformed" max_age:"bar"`
+				}{},
+			},
+			{
+				desc: "too many params",
+				metrics: &struct {
+					Foo func(someLabels, string) prometheus.Gauge `name:"too many input params" help:"only labels are accepted"`
+				}{},
+			},
+			{
+				desc: "labels without label tag",
+				metrics: &struct {
+					Foo func(someLabelsWithoutLabelTag) prometheus.Gauge `name:"nolabeltag" help:"This labels are missing the label tag"`
+				}{},
+			},
+			{
+				desc: "metric registration fails",
+				metrics: &struct {
+					Foo func() prometheus.Gauge `name:"metric" help:"first gauge"`
+					Bar func() prometheus.Gauge `name:"metric" help:"name duplicates the previous one"`
+				}{},
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				initializer := NewInitializer(prometheus.NewRegistry())
+				initializer.MustAddBuilder(prometheusvanilla.GaugeType, prometheusvanilla.BuildGauge)
+				initializer.MustAddBuilder(prometheusvanilla.SummaryType, prometheusvanilla.BuildSummary)
+
+				err := initializer.Init(tc.metrics, "namespace")
+				assert.Error(t, err)
+			})
+		}
+	})
+}

--- a/prometheusvanilla/builders_test.go
+++ b/prometheusvanilla/builders_test.go
@@ -42,11 +42,16 @@ func TestBuilders(t *testing.T) {
 		assert.Implements(t, (*prometheus.Counter)(nil), f(labels))
 	})
 
-	t.Run("Test building a observer", func(t *testing.T) {
+	t.Run("Test building an observer", func(t *testing.T) {
 		f, c, err := BuildObserver(name, help, nameSpace, keys, "")
 		assert.NoError(t, err)
 		assert.Implements(t, (*prometheus.Collector)(nil), c)
 		assert.Implements(t, (*prometheus.Observer)(nil), f(labels))
+	})
+
+	t.Run("Test building an observer with malformed buckets", func(t *testing.T) {
+		_, _, err := BuildObserver(name, help, nameSpace, keys, `buckets:"foo"`)
+		assert.Error(t, err)
 	})
 
 	t.Run("Test building a summary", func(t *testing.T) {
@@ -54,6 +59,11 @@ func TestBuilders(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Implements(t, (*prometheus.Collector)(nil), c)
 		assert.Implements(t, (*prometheus.Summary)(nil), f(labels))
+	})
+
+	t.Run("Test building a summary with malformed max_age", func(t *testing.T) {
+		_, _, err := BuildSummary(name, help, nameSpace, keys, `max_age:"one year"`)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
This bumps the test coverage to 99%, actually there's only one line left uncovered which _can't happen_ but we must leave it there since we don't have generics in golang.