### PR TITLE
Shorten default list of buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2019-06-05
+### Changed
+- Reduced the number of default buckets from 12 to 6 between 0.05s and 10s
+
 ## [0.2.0] - 2019-05-20
 ### Fixed
--  Included the implementation builder for summaries [#14](https://github.com/cabify/gotoprom/pull/14)
+- Included the implementation builder for summaries [#14](https://github.com/cabify/gotoprom/pull/14)
 
 ## [0.1.1] - 2019-05-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.1] - 2019-06-05
 ### Changed
-- Reduced the number of default buckets from 12 to 6 between 0.05s and 10s
+- Reduced the number of default buckets from 12 to 7 between 0.05s and 10s
 
 ## [0.2.0] - 2019-05-20
 ### Fixed

--- a/prometheusvanilla/builders.go
+++ b/prometheusvanilla/builders.go
@@ -121,7 +121,7 @@ func bucketsFromTag(tag reflect.StructTag) ([]float64, error) {
 
 // DefaultBuckets provides a list of buckets you can use when you don't know what to use yet.
 func DefaultBuckets() []float64 {
-	return []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25}
+	return []float64{.05, .1, .5, 1, 5, 10}
 }
 
 func maxAgeFromTag(tag reflect.StructTag) (time.Duration, error) {

--- a/prometheusvanilla/builders.go
+++ b/prometheusvanilla/builders.go
@@ -121,7 +121,7 @@ func bucketsFromTag(tag reflect.StructTag) ([]float64, error) {
 
 // DefaultBuckets provides a list of buckets you can use when you don't know what to use yet.
 func DefaultBuckets() []float64 {
-	return []float64{.05, .1, .5, 1, 5, 10}
+	return []float64{.05, .1, 0.25, .5, 1, 5, 10}
 }
 
 func maxAgeFromTag(tag reflect.StructTag) (time.Duration, error) {


### PR DESCRIPTION
From 13 time series to 7 generated in a histogram as a "sensible default" with network requests in mind. These can be overwritten by any metric definition.