### PR TITLE
Build prometheus.Histogram instead of Observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- *Breaking*: `prometheus.Histogram` is now used to build histograms, instead of `prometheus.Observer`, which means that previous code building `prometheus.Observer` won't compile anymore.
 
 ## [0.3.0] - 2019-10-10
 ### Added

--- a/default.go
+++ b/default.go
@@ -11,7 +11,7 @@ import (
 var DefaultInitializer = NewInitializer(prometheus.DefaultRegisterer)
 
 func init() {
-	DefaultInitializer.MustAddBuilder(prometheusvanilla.ObserverType, prometheusvanilla.BuildObserver)
+	DefaultInitializer.MustAddBuilder(prometheusvanilla.HistogramType, prometheusvanilla.BuildHistogram)
 	DefaultInitializer.MustAddBuilder(prometheusvanilla.CounterType, prometheusvanilla.BuildCounter)
 	DefaultInitializer.MustAddBuilder(prometheusvanilla.GaugeType, prometheusvanilla.BuildGauge)
 	DefaultInitializer.MustAddBuilder(prometheusvanilla.SummaryType, prometheusvanilla.BuildSummary)

--- a/default_test.go
+++ b/default_test.go
@@ -18,7 +18,7 @@ func TestMustAddBuilder(t *testing.T) {
 
 	expectedErr := errors.New("my err")
 
-	typ := prometheusvanilla.ObserverType
+	typ := prometheusvanilla.HistogramType
 	builder := func(
 		name, help, namespace string,
 		labelNames []string,
@@ -43,7 +43,7 @@ func TestAddBuilder(t *testing.T) {
 
 	expectedErr := errors.New("my err")
 
-	typ := prometheusvanilla.ObserverType
+	typ := prometheusvanilla.HistogramType
 	builder := func(
 		name, help, namespace string,
 		labelNames []string,

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -21,11 +21,11 @@ func Test_InitHappyCase(t *testing.T) {
 	}
 
 	var metrics struct {
-		HTTPRequestTime           func(labels) prometheus.Observer `name:"http_request_count" help:"Time taken to serve a HTTP request" metricsbuckets:"0.001,0.005,0.01,0.05,0.1,0.5,1,5,10"`
-		DuvelsEmptied             func(labels) prometheus.Counter  `name:"duvels_emptied" help:"Delirium floor sweep count"`
-		RubberDuckInTherapy       func(labels) prometheus.Gauge    `name:"rubber_ducks_in_therapy" help:"Number of rubber ducks who need help after some intense coding"`
-		BrokenDeploysAccomplished func(labels) prometheus.Summary  `name:"broken_deploys_accomplished" help:"Number of deploys that broke production"`
-		NoLabels                  func() prometheus.Counter        `name:"no_labels" help:"Metric without labels"`
+		HTTPRequestTime           func(labels) prometheus.Histogram `name:"http_request_count" help:"Time taken to serve a HTTP request" metricsbuckets:"0.001,0.005,0.01,0.05,0.1,0.5,1,5,10"`
+		DuvelsEmptied             func(labels) prometheus.Counter   `name:"duvels_emptied" help:"Delirium floor sweep count"`
+		RubberDuckInTherapy       func(labels) prometheus.Gauge     `name:"rubber_ducks_in_therapy" help:"Number of rubber ducks who need help after some intense coding"`
+		BrokenDeploysAccomplished func(labels) prometheus.Summary   `name:"broken_deploys_accomplished" help:"Number of deploys that broke production"`
+		NoLabels                  func() prometheus.Counter         `name:"no_labels" help:"Metric without labels"`
 	}
 
 	gotoprom.MustInit(&metrics, "delirium")
@@ -124,7 +124,7 @@ func Test_LabelsWithBooleans(t *testing.T) {
 	}
 
 	var metrics struct {
-		WithLabels func(labelsWithBools) prometheus.Observer `name:"with_booleans" help:"Parse booleans as strings"`
+		WithLabels func(labelsWithBools) prometheus.Histogram `name:"with_booleans" help:"Parse booleans as strings"`
 	}
 
 	gotoprom.MustInit(&metrics, "testbooleans")
@@ -153,7 +153,7 @@ func Test_LabelsWithInts(t *testing.T) {
 	}
 
 	var metrics struct {
-		WithLabels func(labelsWithInts) prometheus.Observer `name:"with_ints" help:"Parse ints as strings"`
+		WithLabels func(labelsWithInts) prometheus.Histogram `name:"with_ints" help:"Parse ints as strings"`
 	}
 
 	gotoprom.MustInit(&metrics, "testints")
@@ -186,7 +186,7 @@ func Test_DefaultLabelValues(t *testing.T) {
 	}
 
 	var metrics struct {
-		WithLabels func(labelsWithEmptyValues) prometheus.Observer `name:"with_labels" help:"Assign default values"`
+		WithLabels func(labelsWithEmptyValues) prometheus.Histogram `name:"with_labels" help:"Assign default values"`
 	}
 	gotoprom.MustInit(&metrics, "testdefault")
 
@@ -202,7 +202,7 @@ func Test_DefaultLabelValues(t *testing.T) {
 
 func Test_HistogramWithUnsupportedBuckets(t *testing.T) {
 	var metrics struct {
-		Histogram func() prometheus.Observer `name:"with_broken_buckets" help:"Wrong buckets" buckets:"0.005, +inf"`
+		Histogram func() prometheus.Histogram `name:"with_broken_buckets" help:"Wrong buckets" buckets:"0.005, +inf"`
 	}
 	err := gotoprom.Init(&metrics, "test")
 	assert.NotNil(t, err)

--- a/prometheusvanilla/builders.go
+++ b/prometheusvanilla/builders.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	// ObserverType is the type of prometheus.Observer interface
-	ObserverType = reflect.TypeOf((*prometheus.Observer)(nil)).Elem()
+	// HistogramType is the type of prometheus.Histogram interface
+	HistogramType = reflect.TypeOf((*prometheus.Histogram)(nil)).Elem()
 	// CounterType is the type of prometheus.Counter interface
 	CounterType = reflect.TypeOf((*prometheus.Counter)(nil)).Elem()
 	// GaugeType is the type of prometheus.Gauge interface
@@ -56,9 +56,9 @@ func BuildGauge(name, help, namespace string, labelNames []string, tag reflect.S
 	}, gauge, nil
 }
 
-// BuildObserver builds a prometheus.Observer
-// The function it returns returns a prometheus.Observer type as an interface{}
-func BuildObserver(name, help, namespace string, labelNames []string, tag reflect.StructTag) (func(prometheus.Labels) interface{}, prometheus.Collector, error) {
+// BuildHistogram builds a prometheus.Histogram
+// The function it returns returns a prometheus.Histogram type as an interface{}
+func BuildHistogram(name, help, namespace string, labelNames []string, tag reflect.StructTag) (func(prometheus.Labels) interface{}, prometheus.Collector, error) {
 	buckets, err := bucketsFromTag(tag)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build histogram %q: %s", name, err)

--- a/prometheusvanilla/builders_test.go
+++ b/prometheusvanilla/builders_test.go
@@ -46,15 +46,15 @@ func TestBuilders(t *testing.T) {
 		assert.Implements(t, (*prometheus.Counter)(nil), f(labels))
 	})
 
-	t.Run("Test building an observer", func(t *testing.T) {
-		f, c, err := BuildObserver(name, help, nameSpace, keys, "")
+	t.Run("Test building a histogram", func(t *testing.T) {
+		f, c, err := BuildHistogram(name, help, nameSpace, keys, "")
 		assert.NoError(t, err)
 		assert.Implements(t, (*prometheus.Collector)(nil), c)
-		assert.Implements(t, (*prometheus.Observer)(nil), f(labels))
+		assert.Implements(t, (*prometheus.Histogram)(nil), f(labels))
 	})
 
-	t.Run("Test building an observer with malformed buckets", func(t *testing.T) {
-		_, _, err := BuildObserver(name, help, nameSpace, keys, `buckets:"foo"`)
+	t.Run("Test building a histogram with malformed buckets", func(t *testing.T) {
+		_, _, err := BuildHistogram(name, help, nameSpace, keys, `buckets:"foo"`)
 		assert.Error(t, err)
 	})
 


### PR DESCRIPTION
The unprecise usage of `prometheus.Observer` instead of `prometheus.Histogram` may be misleading, since both `Histogram` and `Summary` interfaces embed the `Observer` interface.

This is a breaking change since previous code won't compile with this version, so there's no better moment (except for v2) for doing this than going v1.

Solves https://github.com/cabify/gotoprom/issues/21 although without offering a backwards compatible mechanism because of how packages are loaded and initialized.