### PR TITLE
Histograms: require buckets to be explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for empty buckets tag, which will generate nil buckets for the prometheus Histogram and use default prometheus buckets
+
 ### Changed
 - *Breaking*: `prometheus.Histogram` is now used to build histograms, instead of `prometheus.Observer`, which means that previous code building `prometheus.Observer` won't compile anymore.
+
+### Removed
+- *Breaking*: default buckets on histograms. All histogram should explicitly specify their buckets now or they will fail to build.
 
 ## [0.3.0] - 2019-10-10
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Define your metrics:
 ```go
 var metrics struct {
 	SomeCounter                      func() prometheus.Counter   `name:"some_counter" help:"some counter"`
-	SomeHistogram                    func() prometheus.Histogram `name:"some_histogram" help:"Some histogram with default buckets"`
+	SomeHistogram                    func() prometheus.Histogram `name:"some_histogram" help:"Some histogram with default prometheus buckets" buckets:""`
 	SomeHistogramWithSpecificBuckets func() prometheus.Histogram `name:"some_histogram_with_buckets" help:"Some histogram with custom buckets" buckets:".01,.05,.1"`
 	SomeGauge                        func() prometheus.Gauge     `name:"some_gauge" help:"Some gauge"`
 	SomeSummaryWithSpecificMaxAge    func() prometheus.Summary   `name:"some_summary_with_specific_max_age" help:"Some summary with custom max age" max_age:"20m"`
@@ -170,7 +170,7 @@ So you can later define it as:
 
 ```go
 var metrics struct {
-	DurationSeconds func() prometheusx.TimeHistogram `name:"duration_seconds" help:"Duration in seconds"`
+	DurationSeconds func() prometheusx.TimeHistogram `name:"duration_seconds" help:"Duration in seconds" buckets:".001,.005,.01,.025,.05,.1"`
 }
 
 func init() {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -21,7 +21,7 @@ func Test_InitHappyCase(t *testing.T) {
 	}
 
 	var metrics struct {
-		HTTPRequestTime           func(labels) prometheus.Histogram `name:"http_request_count" help:"Time taken to serve a HTTP request" metricsbuckets:"0.001,0.005,0.01,0.05,0.1,0.5,1,5,10"`
+		HTTPRequestTime           func(labels) prometheus.Histogram `name:"http_request_count" help:"Time taken to serve a HTTP request" buckets:"0.001,0.005,0.01,0.05,0.1,0.5,1,5,10"`
 		DuvelsEmptied             func(labels) prometheus.Counter   `name:"duvels_emptied" help:"Delirium floor sweep count"`
 		RubberDuckInTherapy       func(labels) prometheus.Gauge     `name:"rubber_ducks_in_therapy" help:"Number of rubber ducks who need help after some intense coding"`
 		BrokenDeploysAccomplished func(labels) prometheus.Summary   `name:"broken_deploys_accomplished" help:"Number of deploys that broke production"`
@@ -124,7 +124,7 @@ func Test_LabelsWithBooleans(t *testing.T) {
 	}
 
 	var metrics struct {
-		WithLabels func(labelsWithBools) prometheus.Histogram `name:"with_booleans" help:"Parse booleans as strings"`
+		WithLabels func(labelsWithBools) prometheus.Histogram `name:"with_booleans" help:"Parse booleans as strings" buckets:""`
 	}
 
 	gotoprom.MustInit(&metrics, "testbooleans")
@@ -153,7 +153,7 @@ func Test_LabelsWithInts(t *testing.T) {
 	}
 
 	var metrics struct {
-		WithLabels func(labelsWithInts) prometheus.Histogram `name:"with_ints" help:"Parse ints as strings"`
+		WithLabels func(labelsWithInts) prometheus.Histogram `name:"with_ints" help:"Parse ints as strings" buckets:""`
 	}
 
 	gotoprom.MustInit(&metrics, "testints")
@@ -186,7 +186,7 @@ func Test_DefaultLabelValues(t *testing.T) {
 	}
 
 	var metrics struct {
-		WithLabels func(labelsWithEmptyValues) prometheus.Histogram `name:"with_labels" help:"Assign default values"`
+		WithLabels func(labelsWithEmptyValues) prometheus.Histogram `name:"with_labels" help:"Assign default values" buckets:"10,20,30"`
 	}
 	gotoprom.MustInit(&metrics, "testdefault")
 
@@ -202,7 +202,7 @@ func Test_DefaultLabelValues(t *testing.T) {
 
 func Test_HistogramWithUnsupportedBuckets(t *testing.T) {
 	var metrics struct {
-		Histogram func() prometheus.Histogram `name:"with_broken_buckets" help:"Wrong buckets" buckets:"0.005, +inf"`
+		Histogram func() prometheus.Histogram `name:"with_broken_buckets" help:"Wrong buckets" buckets:"0.005, whatever"`
 	}
 	err := gotoprom.Init(&metrics, "test")
 	assert.NotNil(t, err)

--- a/prometheusvanilla/builders.go
+++ b/prometheusvanilla/builders.go
@@ -106,12 +106,18 @@ func BuildSummary(name, help, namespace string, labelNames []string, tag reflect
 func bucketsFromTag(tag reflect.StructTag) ([]float64, error) {
 	bucketsString, ok := tag.Lookup("buckets")
 	if !ok {
-		return DefaultBuckets(), nil
+		return nil, fmt.Errorf("buckets not specified")
 	}
+
+	if len(bucketsString) == 0 {
+		return nil, nil
+	}
+
 	bucketSlice := strings.Split(bucketsString, ",")
 	buckets := make([]float64, len(bucketSlice))
+
 	var err error
-	for i := 0; i < len(bucketSlice); i++ {
+	for i := range bucketSlice {
 		buckets[i], err = strconv.ParseFloat(bucketSlice[i], 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid bucket specified: %s", err)
@@ -119,11 +125,6 @@ func bucketsFromTag(tag reflect.StructTag) ([]float64, error) {
 	}
 
 	return buckets, nil
-}
-
-// DefaultBuckets provides a list of buckets you can use when you don't know what to use yet.
-func DefaultBuckets() []float64 {
-	return []float64{.05, .1, 0.25, .5, 1, 5, 10}
 }
 
 func maxAgeFromTag(tag reflect.StructTag) (time.Duration, error) {


### PR DESCRIPTION
Default buckets were removed and buckets are now required: writing the buckets is a 5 second effort while forgetting about them and having wrong buckets in production is a lot of work (and maybe even an incident if wrong buckets don't provide enough visibility on an issue)

So now any code without buckets on the histograms will fail to intialize that metrics.

Finally, empty buckets tag is now allowed and it builds an empty buckets slice, which will cause prometheus library to use its own default buckets.

Notice that this change identified an issue in one of our own tests where buckets tag was wrong (`metricsbuckets`) and it was unnoticed because default buckets where used instead.

Solves https://github.com/cabify/gotoprom/issues/23