### PR TITLE
Summaries: require objectives to be explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for empty buckets tag, which will generate nil buckets for the prometheus Histogram and use default prometheus buckets
+- Support for empty objectives tag, which will generate nil objectives for the prometheus Summary and use an empty objectives map after all.
 
 ### Changed
 - *Breaking*: `prometheus.Histogram` is now used to build histograms, instead of `prometheus.Observer`, which means that previous code building `prometheus.Observer` won't compile anymore.
 
 ### Removed
 - *Breaking*: default buckets on histograms. All histogram should explicitly specify their buckets now or they will fail to build.
+- *Breaking*: default objectives on summaries. All summaries should explicitly specify their objectives now or they will fail to build.
+
+### Fixed
+- Summary building was not failing with malformed objectives
 
 ## [0.3.0] - 2019-10-10
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ var metrics struct {
 	SomeHistogram                    func() prometheus.Histogram `name:"some_histogram" help:"Some histogram with default prometheus buckets" buckets:""`
 	SomeHistogramWithSpecificBuckets func() prometheus.Histogram `name:"some_histogram_with_buckets" help:"Some histogram with custom buckets" buckets:".01,.05,.1"`
 	SomeGauge                        func() prometheus.Gauge     `name:"some_gauge" help:"Some gauge"`
-	SomeSummaryWithSpecificMaxAge    func() prometheus.Summary   `name:"some_summary_with_specific_max_age" help:"Some summary with custom max age" max_age:"20m"`
+	SomeSummaryWithSpecificMaxAge    func() prometheus.Summary   `name:"some_summary_with_specific_max_age" help:"Some summary with custom max age" max_age:"20m" objectives:"0.50,0.95,0.99"`
 
 	Requests struct {
 		Total func(requestLabels) prometheus.Count `name:"total" help:"Total amount of requests served"`

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -24,7 +24,7 @@ func Test_InitHappyCase(t *testing.T) {
 		HTTPRequestTime           func(labels) prometheus.Histogram `name:"http_request_count" help:"Time taken to serve a HTTP request" buckets:"0.001,0.005,0.01,0.05,0.1,0.5,1,5,10"`
 		DuvelsEmptied             func(labels) prometheus.Counter   `name:"duvels_emptied" help:"Delirium floor sweep count"`
 		RubberDuckInTherapy       func(labels) prometheus.Gauge     `name:"rubber_ducks_in_therapy" help:"Number of rubber ducks who need help after some intense coding"`
-		BrokenDeploysAccomplished func(labels) prometheus.Summary   `name:"broken_deploys_accomplished" help:"Number of deploys that broke production"`
+		BrokenDeploysAccomplished func(labels) prometheus.Summary   `name:"broken_deploys_accomplished" help:"Number of deploys that broke production" objectives:"0.5,0.9,0.99"`
 		NoLabels                  func() prometheus.Counter         `name:"no_labels" help:"Metric without labels"`
 	}
 
@@ -284,7 +284,7 @@ func Test_SummaryWithSpecifiedMaxAge(t *testing.T) {
 	summaryHelp := "Uses default value for max age"
 
 	var metrics struct {
-		Summary func() prometheus.Summary `name:"without_max_age" help:"Uses default value for max age" max_age:"1s"`
+		Summary func() prometheus.Summary `name:"without_max_age" help:"Uses default value for max age" max_age:"1s" objectives:".5,.9,.99"`
 	}
 
 	err := gotoprom.Init(&metrics, "test")

--- a/prometheusvanilla/builders.go
+++ b/prometheusvanilla/builders.go
@@ -58,6 +58,9 @@ func BuildGauge(name, help, namespace string, labelNames []string, tag reflect.S
 
 // BuildHistogram builds a prometheus.Histogram
 // The function it returns returns a prometheus.Histogram type as an interface{}
+// It requires the buckets tag to be provided
+// If the buckets tag is explicitly empty, then the Histogram will be built with default prometheus buckets
+// which is prometheus.DefBuckets at the time this comment is written.
 func BuildHistogram(name, help, namespace string, labelNames []string, tag reflect.StructTag) (func(prometheus.Labels) interface{}, prometheus.Collector, error) {
 	buckets, err := bucketsFromTag(tag)
 	if err != nil {
@@ -81,6 +84,9 @@ func BuildHistogram(name, help, namespace string, labelNames []string, tag refle
 
 // BuildSummary builds a prometheus.Summary
 // The function it returns returns a prometheus.Summary type as an interface{}
+// It requires the objectives tag to be provided, and optionally the max_age tag
+// If the objectives tag is explicitly empty, then the Summary will be built with default prometheus objectives
+// which is no objectives at the time this comment is written.
 func BuildSummary(name, help, namespace string, labelNames []string, tag reflect.StructTag) (func(prometheus.Labels) interface{}, prometheus.Collector, error) {
 	maxAge, err := maxAgeFromTag(tag)
 	if err != nil {


### PR DESCRIPTION
Just like https://github.com/cabify/gotoprom/pull/27 but for Summaries,
same reasons apply, TL;DR: explicit is better than implicit.

Also fixed summary builder not failing when objectives were malformed.