### PR TITLE
Allow empty namespace, namespace chain for nested structs

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -87,20 +87,6 @@ func TestInitializer_Init(t *testing.T) {
 				}{},
 			},
 			{
-				desc: "sub-struct doesn't define its namespace",
-				metrics: &struct {
-					Inner struct{}
-				}{},
-			},
-			{
-				desc: "sub-struct can't be initialized",
-				metrics: &struct {
-					Inner struct {
-						Deeper struct{} `thisdoesnothaveanamespace:"nothing"`
-					} `namespace:"thishasanamespace"`
-				}{},
-			},
-			{
 				desc: "non-exported field",
 				metrics: &struct {
 					foo func() prometheus.Gauge `name:"unexported" help:"this can't be set"`


### PR DESCRIPTION
The namespace is optional.

Nested structs without a namespace are useful for embedded structs.

```go
var metrics struct {
	BaseMetrics
	Sub         SubMetrics `namespace:"sub"`
	SomeCounter func(...) prometheus.Counter
}
```